### PR TITLE
Remove the contact form

### DIFF
--- a/content/home/contact-us.md
+++ b/content/home/contact-us.md
@@ -7,4 +7,4 @@ homeType: contactUs
 weight: 100
 ---
 
-If you’d like to get in touch, either fill in the form or email us at [{{< param email >}}](mailto:{{< param email >}}). Please be aware all our tasks are done by our members as volunteers, so the speed of replies is not consistent.
+If you’d like to get in touch, email us at [{{< param email >}}](mailto:{{< param email >}}). Please be aware all our tasks are done by our members as volunteers, so the speed of replies is not consistent.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -28,7 +28,6 @@
           <div class="container">
             <h2 class="title">{{ .Title }}</h2>
             <div class="content">{{ .Content }}</div>
-            {{ partial "contact-form" }}
           </div>
         </section>
       {{ end }}


### PR DESCRIPTION
Remove the contact from from the website so we can remove the need to pay for Netlify form handing.